### PR TITLE
Update for compatibility with development Cuis

### DIFF
--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -1,4 +1,4 @@
-'From Cuis7.3 [latest update: #6910] on 12 December 2024 at 12:22:38 pm'!
+'From Cuis7.3 [latest update: #6943] on 22 December 2024 at 2:09:54 am'!
 'Description This is a variation of Cuis Finder by Nicolas Papagna, that uses a popup morph as user interface.
 
 Finder is a system-wide search tool for Cuis Smalltalk.
@@ -19,7 +19,7 @@ Also, you can use catalog specific shortcuts:
     alt-s : Selectors catalog.
     alt-p : System categories catalog.
     alt-t : Tools catalog.'!
-!provides: 'PopupFinder' 1 64!
+!provides: 'PopupFinder' 1 65!
 !requires: 'KeyStrokes' 1 65 nil!
 SystemOrganization addCategory: #'PopupFinder-Model'!
 SystemOrganization addCategory: #'PopupFinder-UI'!
@@ -730,11 +730,11 @@ delete
 	
 	^ super delete.! !
 
-!FinderSearchBarMorph methodsFor: 'layout' stamp: 'MM 9/25/2020 14:41:12'!
+!FinderSearchBarMorph methodsFor: 'layout' stamp: 'Ez3 12/22/2024 01:50:22'!
 layoutSubmorphs
 	
 	layoutMorph
-		morphPosition: 0@0
+		position: 0@0
 		extent: self morphExtent.! !
 
 !FinderSearchBarMorph methodsFor: 'stepping' stamp: 'HAW 6/30/2020 09:31:12'!
@@ -863,14 +863,15 @@ processNonEmptySearchQuery: aQuery
 		valueFiltering: Smalltalk classNames
 		with: aQuery! !
 
-!ClassNamesCatalog methodsFor: 'browsing' stamp: 'NPM 4/2/2020 02:25:34'!
+!ClassNamesCatalog methodsFor: 'browsing' stamp: 'Ez3 12/22/2024 01:53:37'!
 browse: aClassName 
 	
 	| class |
 	class := (Smalltalk classNamed: aClassName).
 	
 	BrowserWindow
-		fullOnClass: class! !
+		fullOnClass: class
+		selector: nil! !
 
 !ClassNamesCatalog methodsFor: 'as yet unclassified' stamp: 'MM 2/6/2021 15:11:15'!
 keyStrokeCharacter

--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -1,4 +1,4 @@
-'From Cuis7.3 [latest update: #6943] on 22 December 2024 at 2:09:54 am'!
+'From Cuis7.3 [latest update: #6943] on 22 December 2024 at 3:04:14 am'!
 'Description This is a variation of Cuis Finder by Nicolas Papagna, that uses a popup morph as user interface.
 
 Finder is a system-wide search tool for Cuis Smalltalk.
@@ -19,7 +19,7 @@ Also, you can use catalog specific shortcuts:
     alt-s : Selectors catalog.
     alt-p : System categories catalog.
     alt-t : Tools catalog.'!
-!provides: 'PopupFinder' 1 65!
+!provides: 'PopupFinder' 1 66!
 !requires: 'KeyStrokes' 1 65 nil!
 SystemOrganization addCategory: #'PopupFinder-Model'!
 SystemOrganization addCategory: #'PopupFinder-UI'!
@@ -572,12 +572,12 @@ openInWorld
 		w activeHand newKeyboardFocus: self submorphToFocusKeyboard ].
 	FinderMorph current: self.! !
 
-!FinderMorph class methodsFor: 'class initialization' stamp: 'MM 11/9/2021 14:29:49'!
+!FinderMorph class methodsFor: 'class initialization' stamp: 'Ez3 12/22/2024 02:53:12'!
 initialize
 
 	self configureAsClassFinder.
 	
-	self inform:  'Finder morph installed. Use cmd+f to open.'! !
+	self inform:  'Finder morph installed. Use shift+enter to open.'! !
 
 !FinderMorph class methodsFor: 'instance creation' stamp: 'MM 2/8/2021 09:54:23'!
 open
@@ -592,11 +592,11 @@ openOn: aFinder
 		buildMorphicWindow;
 		openInWorld! !
 
-!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 12/12/2024 12:22:14'!
+!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'Ez3 12/22/2024 02:30:22'!
 configureAsClassFinder
 	"self configureAsClassFinder"
 	
-	KeyStrokes on: 'ctrl+#isReturnKey' in: WorldMorph send: #open to: FinderMorph.
+	KeyStrokes on: 'shift+#isReturnKey' in: WorldMorph send: #open to: FinderMorph.
 
 	! !
 


### PR DESCRIPTION
Hi!

This updates message names for compatibility, and sets the default keybinding back to shift-enter. Command-f or Control-f conflict with the keybindings in WorldMorph>>keyStroke: and since those “win”, the findAndBrowseClass dialog shows up instead of the finder popup. 

Tested manually with Cuis 7.3 - 6895