### PR TITLE
Update PopupFinder for Cuis 7.9

### DIFF
--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -719,11 +719,19 @@ innerMorphClass
 !FinderSearchTextModelMorph methodsFor: 'as yet unclassified' stamp: 'MM 9/25/2020 14:48:53'!
 mouseLeave: evt! !
 
-!FinderSearchInnerTextMorph methodsFor: 'as yet unclassified' stamp: 'HAW 3/21/2025 23:14:54'!
+!FinderSearchInnerTextMorph methodsFor: 'as yet unclassified' stamp: 'HAW 6/29/2026 14:20:00'!
 keyboardFocusChange: aBoolean
-	"Notify change due to green border for keyboard focus"
-	aBoolean ifFalse: [
-		(self firstOwnerSuchThat: [ :m | m class ==  FinderMorph ]) delete ]! !
+	"Notify change due to green border for keyboard focus.
+	Close the popup finder only when keyboard focus leaves it entirely; moving focus
+	to an inner morph such as a catalog tab button must keep the finder open."
+	| finder hand newFocus |
+	aBoolean ifTrue: [ ^ self ].
+	finder := self firstOwnerSuchThat: [ :m | m class == FinderMorph ].
+	finder ifNil: [ ^ self ].
+	hand := self runningWorld ifNotNil: [ :w | w activeHand ].
+	newFocus := hand ifNotNil: [ :h | h keyboardFocus ].
+	(newFocus notNil and: [ newFocus == finder or: [ newFocus hasOwner: finder ] ])
+		ifFalse: [ finder delete ]! !
 
 !Catalog methodsFor: 'accessing' stamp: 'NPM 3/28/2020 02:38:49'!
 name

--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -1,4 +1,4 @@
-'From Cuis7.3 [latest update: #7087] on 21 March 2025 at 11:17:21 pm'!
+'From Cuis7.9 [latest update: #7983] on 29 June 2026 at 2:20:00 pm'!
 'Description This is a variation of Cuis Finder by Nicolas Papagna, that uses a popup morph as user interface.
 
 Finder is a system-wide search tool for Cuis Smalltalk.
@@ -9,7 +9,7 @@ It is inspired by Pharo''s Spotter and the search feature provided by JetBrains 
 
 Use shift + enter key to open the finder.
 
-tab or left arrow and right arrow keys to change catalog.
+tab key to change catalog (left and right arrow keys move the cursor in the search field).
 
 Also, you can use catalog specific shortcuts:
 
@@ -19,7 +19,7 @@ Also, you can use catalog specific shortcuts:
     alt-s : Selectors catalog.
     alt-p : System categories catalog.
     alt-t : Tools catalog.'!
-!provides: 'PopupFinder' 1 69!
+!provides: 'PopupFinder' 1 70!
 !requires: 'KeyStrokes' 1 65 nil!
 SystemOrganization addCategory: #'PopupFinder-Model'!
 SystemOrganization addCategory: #'PopupFinder-UI'!
@@ -388,17 +388,6 @@ submorphToFocusKeyboard
 
 	^ searchBar searchField! !
 
-!FinderMorph methodsFor: 'events-old protocol' stamp: 'MM 9/7/2020 11:38:33'!
-update: aSymbol
-
-	model
-		isBrowseSelectedResultEvent: aSymbol
-		ifTrue:  [ ^ self closeBoxHit ].
-		
-	model
-		isCloseEvent: aSymbol
-		ifTrue:  [ ^ self closeBoxHit ].! !
-
 !FinderMorph methodsFor: 'shortcuts' stamp: 'MM 9/7/2020 11:38:33'!
 forwardToResults: aKeyboardEvent
 
@@ -406,24 +395,8 @@ forwardToResults: aKeyboardEvent
 		isNil not
 ! !
 
-!FinderMorph methodsFor: 'shortcuts' stamp: 'MM 9/7/2020 20:35:32'!
-processArrowLeftOrRight: aKeyboardEvent 
-	
-	aKeyboardEvent isArrowLeft 
-		ifTrue: [ 
-			model selectPreviousCatalog.
-			^ true ].
-		
-	aKeyboardEvent isArrowRight 
-		ifTrue: [ 
-			model selectNextCatalog.
-			^ true ].
-
-	^ false
-	! !
-
 !FinderMorph methodsFor: 'shortcuts' stamp: 'MM 9/7/2020 11:38:33'!
-processArrowUpOrDown: aKeyboardEvent 
+processArrowUpOrDown: aKeyboardEvent
 	
 	aKeyboardEvent isArrowUp 
 		ifTrue: [ 
@@ -460,18 +433,15 @@ processEscKey: aKeyboardEvent
 		
 	^ aKeyboardEvent isEsc! !
 
-!FinderMorph methodsFor: 'shortcuts' stamp: 'MM 2/6/2021 15:02:02'!
-processKeyStroke: aKeyboardEvent 
-	
+!FinderMorph methodsFor: 'shortcuts' stamp: 'JEC 6/Jan/2026 17:21:19'!
+processKeyStroke: aKeyboardEvent
+
 	(self processTab: aKeyboardEvent)
 		ifTrue: [ ^ true ].
-	
+
 	(self processArrowUpOrDown: aKeyboardEvent)
 		ifTrue: [ ^ true ].
-		
-	(self processArrowLeftOrRight: aKeyboardEvent)
-		ifTrue: [^true].
-		
+
 	(self processReturnKey: aKeyboardEvent)
 		ifTrue: [ ^ true ].
 		
@@ -1221,18 +1191,6 @@ initializeWithAll: aCollectionOfCatalogs
 	self initializeResults.
 	self initializeCatalogs: aCollectionOfCatalogs.	
 	self initializeEventNames.! !
-
-!Finder methodsFor: 'events-old protocol' stamp: 'NPM 4/2/2020 01:04:08'!
-isBrowseSelectedResultEvent: anEvent ifTrue: aBlock
-	
-	anEvent = browseSelectedResultEvent
-		ifTrue: aBlock! !
-
-!Finder methodsFor: 'events-old protocol' stamp: 'NPM 4/20/2020 17:06:25'!
-isCloseEvent: anEvent ifTrue: aBlock
-
-	anEvent = closeEvent
-		ifTrue: aBlock! !
 
 !Finder methodsFor: 'events-old protocol' stamp: 'NPM 4/2/2020 01:05:06'!
 isSelectedCatalogChange: anEvent ifTrue: aBlock

--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -613,10 +613,10 @@ registerKeyStrokeHandler
 		setProperty: #'keyStroke:'
 		toValue: [ :event | self processKeyStroke ]! !
 
-!FinderSearchBarMorph methodsFor: 'key stroke handling' stamp: 'NPM 5/9/2020 13:04:54'!
+!FinderSearchBarMorph methodsFor: 'key stroke handling' stamp: 'HAW 3/Nov/2021 21:28:44'!
 unregisterKeyStrokeHandler
 
-	searchBox textMorph
+	searchBox innerTextMorph
 		removeProperty: #'keyStroke:'! !
 
 !FinderSearchBarMorph methodsFor: 'initialization' stamp: 'Ez3 1/28/2025 22:52:36'!

--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -578,11 +578,6 @@ current
 current: anInstance
 	CurrentFinder _ anInstance! !
 
-!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 9/8/2020 17:48:34'!
-isFindClassShortcut: aKeyboardEvent
-
-	^ aKeyboardEvent shiftPressed and: [ aKeyboardEvent isReturnKey ]! !
-
 !FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 9/24/2022 10:20:45'!
 worldMenuOptions
 	^ `{{

--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -560,7 +560,7 @@ openOn: aFinder
 		buildMorphicWindow;
 		openInWorld! !
 
-!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'Ez3 12/22/2024 02:30:22'!
+!FinderMorph class methodsFor: 'class initialization private' stamp: 'Ez3 12/22/2024 02:30:22'!
 configureAsClassFinder
 	"self configureAsClassFinder"
 	
@@ -568,15 +568,15 @@ configureAsClassFinder
 
 	! !
 
-!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 9/7/2020 12:10:49'!
+!FinderMorph class methodsFor: 'current finder' stamp: 'MM 9/7/2020 12:10:49'!
 current
 	^ CurrentFinder! !
 
-!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 9/7/2020 12:11:06'!
+!FinderMorph class methodsFor: 'current finder' stamp: 'MM 9/7/2020 12:11:06'!
 current: anInstance
 	CurrentFinder _ anInstance! !
 
-!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'JEC 10/Jan/2026 23:03:46'!
+!FinderMorph class methodsFor: 'current finder' stamp: 'JEC 10/Jan/2026 23:03:46'!
 deleteCurrent
 	CurrentFinder := nil! !
 

--- a/Tools/PopupFinder.pck.st
+++ b/Tools/PopupFinder.pck.st
@@ -421,16 +421,12 @@ processCatalogKey: aKeyboardEvent
 					ifTrue: [model changeSelectedCatalog: catalog. ^ true]]].
 	^ false! !
 
-!FinderMorph methodsFor: 'shortcuts' stamp: 'MM 9/7/2020 12:08:12'!
+!FinderMorph methodsFor: 'shortcuts' stamp: 'JEC 10/Jan/2026 23:05:49'!
 processEscKey: aKeyboardEvent
 
-	(aKeyboardEvent isEsc)
-		ifTrue: [ 
-			model close. 
-			self delete. 
-			self runningWorld activeHand newKeyboardFocus: self runningWorld.
-			FinderMorph current: nil].
-		
+	aKeyboardEvent isEsc
+		ifTrue: [ self delete ].
+
 	^ aKeyboardEvent isEsc! !
 
 !FinderMorph methodsFor: 'shortcuts' stamp: 'JEC 6/Jan/2026 17:21:19'!
@@ -501,12 +497,14 @@ defaultButtonPaneHeight
 defaultColor
 	^ Color veryVeryLightGray! !
 
-!FinderMorph methodsFor: 'as yet unclassified' stamp: 'MM 9/24/2022 10:10:03'!
+!FinderMorph methodsFor: 'submorphs-add/remove' stamp: 'JEC 10/Jan/2026 23:05:21'!
 delete
-	super delete.
-	FinderMorph current: nil.
+
+	model close.
+	self class deleteCurrent.
 	focusFollowsMouse ifTrue: [Preferences at: #focusFollowsMouse put: true].
-	Display restore.! !
+	self runningWorld activeHand newKeyboardFocus: self runningWorld.
+	super delete.! !
 
 !FinderMorph methodsFor: 'as yet unclassified' stamp: 'MM 9/25/2020 14:39:28'!
 handlesKeyboard
@@ -577,6 +575,10 @@ current
 !FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 9/7/2020 12:11:06'!
 current: anInstance
 	CurrentFinder _ anInstance! !
+
+!FinderMorph class methodsFor: 'as yet unclassified' stamp: 'JEC 10/Jan/2026 23:03:46'!
+deleteCurrent
+	CurrentFinder := nil! !
 
 !FinderMorph class methodsFor: 'as yet unclassified' stamp: 'MM 9/24/2022 10:20:45'!
 worldMenuOptions
@@ -659,12 +661,12 @@ timeSinceLastKeyStroke
 
 	^ DateAndTime now - dateAndTimeOfLastKeyStroke! !
 
-!FinderSearchBarMorph methodsFor: 'submorphs-add/remove' stamp: 'NPM 5/9/2020 13:04:54'!
-delete
+!FinderSearchBarMorph methodsFor: 'submorphs-add/remove' stamp: 'JEC 10/Jan/2026 23:10:49'!
+clearDependencyAndEvents
 
 	self unregisterKeyStrokeHandler.
-	
-	^ super delete.! !
+
+	^ super clearDependencyAndEvents.! !
 
 !FinderSearchBarMorph methodsFor: 'stepping' stamp: 'HAW 6/30/2020 09:31:12'!
 stepAt: millisecondSinceLast

--- a/Tools/PopupFinderLiveTyping.pck.st
+++ b/Tools/PopupFinderLiveTyping.pck.st
@@ -1,0 +1,11 @@
+'From Cuis7.9 [latest update: #7983] on 29 June 2026 at 2:20:00 pm'!
+'Description '!
+!provides: 'PopupFinderLiveTyping' 1 1!
+!requires: 'PopupFinder' 1 70 nil!
+
+
+
+!FinderSearchInnerTextMorph methodsFor: '*PopupFinderLiveTyping' stamp: 'HAW 12/Jan/2026 17:05:12'!
+wantsBalloon
+
+	^false! !


### PR DESCRIPTION
Updates the PopupFinder tool so it works on the current base image (Cuis7.9 #7983). Ports the outstanding fixes from Hernán Wilkinson's `cuis-finder-asWidget` fork (which had renamed the package and diverged, so changes were applied by hand rather than cherry-picked) and adds two fixes specific to 7.9.

## Changes

Ported from the reference fork (original authors' initials preserved in the method stamps):

- **Fix left and right arrow keys to move the cursor in the search field** instead of switching catalog (tab still switches). Removes the dead `#update:`, `#processArrowLeftOrRight:`, `Finder>>#isBrowseSelectedResultEvent:ifTrue:` and `Finder>>#isCloseEvent:ifTrue:`.
- **Delete unused `#isFindClassShortcut:`**.
- **Replace `FinderSearchBarMorph>>#delete` with `#clearDependencyAndEvents`.** `#delete` is not recursive; when `#delete` is sent to a Morph the recursive teardown hook sent to every submorph is `#clearDependencyAndEvents`. Reworks `FinderMorph>>#delete`/`#processEscKey:` and adds `FinderMorph class>>#deleteCurrent`.
- **Classify class methods on `FinderMorph` class side.**

New, specific to Cuis 7.9:

- **Fix `#unregisterKeyStrokeHandler`:** `TextModelMorph>>#textMorph` was removed in 7.9, so it now sends `#innerTextMorph` (symmetric with `#registerKeyStrokeHandler`). This DNU was exposed once teardown goes through `#clearDependencyAndEvents`.
- **Keep the finder open when keyboard focus moves to an inner morph.** In 7.9 `PluggableButtonMorph` grabs keyboard focus on mouse down, so clicking a catalog tab used to close the finder; `#keyboardFocusChange:` now only closes when focus leaves the finder entirely.
- **Add optional `PopupFinderLiveTyping` package** that suppresses the search field balloon when LiveTyping is loaded. It is not required by `PopupFinder` and is not loaded automatically (add-on for a VM plugin that may not be installed).